### PR TITLE
fix: swapped the two fishes comparisons with beef

### DIFF
--- a/src/components/visualizations/PoissonBlanc.js
+++ b/src/components/visualizations/PoissonBlanc.js
@@ -28,9 +28,9 @@ export default function PoissonBlanc() {
         </Equivalent>
         <Equals>=</Equals>
         <Equivalent size={[12, 7, 30]}>
-          <Emojis>🐟🐟🐟🐟🐟🐟🐟</Emojis>
+          <Emojis>🐟🐟🐟🐟</Emojis>
           <Label>
-            7 repas avec
+            4 repas avec
             <br />
             du poisson blanc
           </Label>

--- a/src/components/visualizations/PoissonGras.js
+++ b/src/components/visualizations/PoissonGras.js
@@ -28,9 +28,9 @@ export default function PoissonGras() {
         </Equivalent>
         <Equals>=</Equals>
         <Equivalent size={[10, 7, 22]}>
-          <Emojis margin={70}>🐟🐟🐟🐟</Emojis>
+          <Emojis margin={70}>🐟🐟🐟🐟🐟🐟🐟</Emojis>
           <Label>
-            4 repas avec
+            7 repas avec
             <br />
             du poisson gras
           </Label>


### PR DESCRIPTION
fixes https://github.com/datagir/impactco2/issues/271

Based on `src/data/categories/repas.json`, the numbers are correct, they were just swapped.

Voici le détail des calculs:

- Le repas avec du boeuf est à 7.26. https://github.com/datagir/impactco2/blob/b1766fad8942ac2d85cb14f55af93ea00382fc3a/src/data/categories/repas.json#L9
- Le repas avec du poisson blanc est à 1.98. Un repas avec du boeuf est équivalent à 7.26/1.98=3.66 repas avec du poisson blanc. https://github.com/datagir/impactco2/blob/b1766fad8942ac2d85cb14f55af93ea00382fc3a/src/data/categories/repas.json#L57
- Le repas avec du poisson gras est à 1.11. Un repas avec du boeuf est équivalent à 7.26/1.11=6.54 repas avec du poisson gras. https://github.com/datagir/impactco2/blob/b1766fad8942ac2d85cb14f55af93ea00382fc3a/src/data/categories/repas.json#L73